### PR TITLE
Limit capybara dsl

### DIFF
--- a/lib/howitzer/web/element.rb
+++ b/lib/howitzer/web/element.rb
@@ -16,36 +16,43 @@ module Howitzer
 
       # This module holds page validation class methods
       module ClassMethods
-        private
+        protected
 
         # TODO: describe me
         #
         def element(name, *args)
           validate_arguments!(args)
-
-          define_method("#{name}_element") do |*block_args|
-            find(*convert_arguments(args, block_args))
-          end
-
-          define_method("#{name}_elements") do |*block_args|
-            all(*convert_arguments(args, block_args))
-          end
-
-          define_method("has_#{name}_element?") do |*block_args|
-            has_selector?(*convert_arguments(args, block_args))
-          end
-
-          define_method("has_no_#{name}_element?") do |*block_args|
-            has_no_selector?(*convert_arguments(args, block_args))
-          end
-
-          private "#{name}_element", "#{name}_elements"
+          define_dynamic_methods(name, args)
         end
+
+        private
 
         def validate_arguments!(args)
           return unless args.map(&:class).count(Proc) > 1
 
           raise BadElementParamsError, 'Using more than 1 proc in arguments is forbidden'
+        end
+
+        def define_dynamic_methods(name, args)
+          session = Capybara.current_session
+
+          define_method("#{name}_element") do |*block_args|
+            session.find(*convert_arguments(args, block_args))
+          end
+
+          define_method("#{name}_elements") do |*block_args|
+            session.all(*convert_arguments(args, block_args))
+          end
+
+          define_method("has_#{name}_element?") do |*block_args|
+            session.has_selector?(*convert_arguments(args, block_args))
+          end
+
+          define_method("has_no_#{name}_element?") do |*block_args|
+            session.has_no_selector?(*convert_arguments(args, block_args))
+          end
+
+          private "#{name}_element", "#{name}_elements"
         end
       end
     end

--- a/lib/howitzer/web/page.rb
+++ b/lib/howitzer/web/page.rb
@@ -13,7 +13,7 @@ module Howitzer
       UnknownPage = Class.new
       PROXY_CAPYBARA_METHODS = Capybara::Session::SESSION_METHODS +
                                Capybara::Session::MODAL_METHODS +
-                               [:driver]
+                               [:driver, :text]
 
       include Singleton
       include Element
@@ -67,18 +67,6 @@ module Howitzer
 
       ##
       #
-      # Returns body text of html page
-      #
-      # *Returns:*
-      # * +string+ - Body text
-      #
-
-      def self.text
-        Capybara.current_session.find('body').text
-      end
-
-      ##
-      #
       # Tries to identify current page name or raise error if ambiguous page matching
       #
       # *Returns:*
@@ -90,9 +78,7 @@ module Howitzer
         if page_list.count.zero?
           UnknownPage
         elsif page_list.count > 1
-          log.error AmbiguousPageMatchingError,
-                    "Current page matches more that one page class (#{page_list.join(', ')}).\n" \
-                    "\tCurrent url: #{instance.current_url}\n\tCurrent title: #{instance.title}"
+          log.error AmbiguousPageMatchingError, ambiguous_page_msg(page_list)
         elsif page_list.count == 1
           page_list.first
         end
@@ -109,8 +95,7 @@ module Howitzer
       def self.wait_for_opened(timeout = settings.timeout_small)
         end_time = ::Time.now + timeout
         opened? ? return : sleep(0.5) until ::Time.now > end_time
-        log.error IncorrectPageError, "Current page: #{current_page}, expected: #{self}.\n" \
-                  "\tCurrent url: #{instance.current_url}\n\tCurrent title: #{instance.title}"
+        log.error IncorrectPageError, incorrect_page_msg
       end
 
       ##
@@ -152,6 +137,16 @@ module Howitzer
 
         def parent_url
           @root_url || Helpers.app_url
+        end
+
+        def incorrect_page_msg
+          "Current page: #{current_page}, expected: #{self}.\n" \
+                    "\tCurrent url: #{instance.current_url}\n\tCurrent title: #{instance.title}"
+        end
+
+        def ambiguous_page_msg(page_list)
+          "Current page matches more that one page class (#{page_list.join(', ')}).\n" \
+                    "\tCurrent url: #{instance.current_url}\n\tCurrent title: #{instance.title}"
         end
       end
 

--- a/lib/howitzer/web/page.rb
+++ b/lib/howitzer/web/page.rb
@@ -67,18 +67,6 @@ module Howitzer
 
       ##
       #
-      # Returns current url
-      #
-      # *Returns:*
-      # * +string+ - Current url
-      #
-
-      def self.current_url
-        Capybara.current_session.current_url
-      end
-
-      ##
-      #
       # Returns body text of html page
       #
       # *Returns:*
@@ -104,7 +92,7 @@ module Howitzer
         elsif page_list.count > 1
           log.error AmbiguousPageMatchingError,
                     "Current page matches more that one page class (#{page_list.join(', ')}).\n" \
-                    "\tCurrent url: #{current_url}\n\tCurrent title: #{title}"
+                    "\tCurrent url: #{instance.current_url}\n\tCurrent title: #{instance.title}"
         elsif page_list.count == 1
           page_list.first
         end
@@ -122,7 +110,7 @@ module Howitzer
         end_time = ::Time.now + timeout
         opened? ? return : sleep(0.5) until ::Time.now > end_time
         log.error IncorrectPageError, "Current page: #{current_page}, expected: #{self}.\n" \
-                  "\tCurrent url: #{current_url}\n\tCurrent title: #{title}"
+                  "\tCurrent url: #{instance.current_url}\n\tCurrent title: #{instance.title}"
       end
 
       ##

--- a/lib/howitzer/web/page_validator.rb
+++ b/lib/howitzer/web/page_validator.rb
@@ -104,12 +104,12 @@ module Howitzer
 
         def validate_by_url(pattern)
           PageValidator.validations[name][:url] =
-            -> (web_page) { pattern === web_page.current_url }
+            -> (web_page) { pattern === web_page.instance.current_url }
         end
 
         def validate_by_title(pattern)
           PageValidator.validations[name][:title] =
-            -> (web_page) { pattern === web_page.title }
+            -> (web_page) { pattern === web_page.instance.title }
         end
 
         def validate_by_type(type, value, additional_value)

--- a/spec/unit/lib/web/element_spec.rb
+++ b/spec/unit/lib/web/element_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe Howitzer::Web::Element do
       it 'should create public :has_no_foo_element? instance method' do
         expect(subject.new.public_methods(false)).to include(:has_no_foo_element?)
       end
-      it 'should be private class method' do
+      it 'should be protected class method' do
         expect { subject.element :bar }.to raise_error(NoMethodError)
-        expect(subject.private_methods(true)).to include(:element)
+        expect(subject.protected_methods(true)).to include(:element)
       end
     end
     context 'when 1 param is proc' do
@@ -51,9 +51,9 @@ RSpec.describe Howitzer::Web::Element do
       it 'should create public :has_no_foo_element? instance method' do
         expect(subject.new.public_methods(false)).to include(:has_no_foo_element?)
       end
-      it 'should be private class method' do
+      it 'should be protected class method' do
         expect { subject.element :bar }.to raise_error(NoMethodError)
-        expect(subject.private_methods(true)).to include(:element)
+        expect(subject.protected_methods(true)).to include(:element)
       end
     end
     context 'when 2 params are proc' do
@@ -74,18 +74,12 @@ RSpec.describe Howitzer::Web::Element do
 
   describe 'dynamic_methods' do
     let(:web_page_object) { web_page_class.new }
+    let(:session) { double(:session) }
     before do
+      allow(Capybara).to receive(:current_session) { session }
       web_page_class.class_eval do
         element :foo, :xpath, ->(title) { "//a[.='#{title}']" }
         element :bar, '.someclass'
-
-        def find(*_args); end
-
-        def all(*_args); end
-
-        def has_selector?(*_args); end
-
-        def has_no_selector?(*_args); end
       end
     end
     after { subject }
@@ -93,41 +87,41 @@ RSpec.describe Howitzer::Web::Element do
     describe '#name_element' do
       context 'when simple selector' do
         subject { web_page_object.send(:bar_element) }
-        it { expect(web_page_object).to receive(:find).with('.someclass') }
+        it { expect(session).to receive(:find).with('.someclass') }
       end
       context 'when lambda selector' do
         subject { web_page_object.send(:foo_element, 'Hello') }
-        it { expect(web_page_object).to receive(:find).with(:xpath, "//a[.='Hello']") }
+        it { expect(session).to receive(:find).with(:xpath, "//a[.='Hello']") }
       end
     end
     describe '#name_elements' do
       context 'when simple selector' do
         subject { web_page_object.send(:bar_elements) }
-        it { expect(web_page_object).to receive(:all).with('.someclass') }
+        it { expect(session).to receive(:all).with('.someclass') }
       end
       context 'when lambda selector' do
         subject { web_page_object.send(:foo_elements, 'Hello') }
-        it { expect(web_page_object).to receive(:all).with(:xpath, "//a[.='Hello']") }
+        it { expect(session).to receive(:all).with(:xpath, "//a[.='Hello']") }
       end
     end
     describe '#has_name_element?' do
       context 'when simple selector' do
         subject { web_page_object.send(:has_bar_element?) }
-        it { expect(web_page_object).to receive(:has_selector?).with('.someclass') }
+        it { expect(session).to receive(:has_selector?).with('.someclass') }
       end
       context 'when lambda selector' do
         subject { web_page_object.send(:has_foo_element?, 'Hello') }
-        it { expect(web_page_object).to receive(:has_selector?).with(:xpath, "//a[.='Hello']") }
+        it { expect(session).to receive(:has_selector?).with(:xpath, "//a[.='Hello']") }
       end
     end
     describe '#has_no_name_element?' do
       context 'when simple selector' do
         subject { web_page_object.send(:has_no_bar_element?) }
-        it { expect(web_page_object).to receive(:has_no_selector?).with('.someclass') }
+        it { expect(session).to receive(:has_no_selector?).with('.someclass') }
       end
       context 'when lambda selector' do
         subject { web_page_object.send(:has_no_foo_element?, 'Hello') }
-        it { expect(web_page_object).to receive(:has_no_selector?).with(:xpath, "//a[.='Hello']") }
+        it { expect(session).to receive(:has_no_selector?).with(:xpath, "//a[.='Hello']") }
       end
     end
   end

--- a/spec/unit/lib/web/page_spec.rb
+++ b/spec/unit/lib/web/page_spec.rb
@@ -59,35 +59,6 @@ RSpec.describe Howitzer::Web::Page do
     end
   end
 
-  describe '.current_url' do
-    let(:page) { double }
-    subject { described_class.current_url }
-    it do
-      expect(session).to receive(:current_url) { 'google.com' }
-      is_expected.to eq('google.com')
-    end
-  end
-
-  describe '.current_url' do
-    let(:page) { double }
-    subject { described_class.current_url }
-    it do
-      expect(session).to receive(:current_url) { 'google.com' }
-      is_expected.to eq('google.com')
-    end
-  end
-
-  describe '.text' do
-    let(:page) { double }
-    let(:find) { double }
-    subject { described_class.text }
-    it do
-      expect(session).to receive(:find).with('body') { find }
-      expect(find).to receive(:text) { 'some body text' }
-      is_expected.to eq('some body text')
-    end
-  end
-
   describe '.current_page' do
     subject { described_class.current_page }
     context 'when matched_pages has no pages' do
@@ -98,8 +69,9 @@ RSpec.describe Howitzer::Web::Page do
       let(:foo_page) { double(inspect: 'FooPage') }
       let(:bar_page) { double(inspect: 'BarPage') }
       before do
-        allow(described_class).to receive(:current_url) { 'http://test.com' }
-        allow(described_class).to receive(:title) { 'Test site' }
+        allow_any_instance_of(described_class).to receive(:check_validations_are_defined!) { true }
+        allow(session).to receive(:current_url) { 'http://test.com' }
+        allow(session).to receive(:title) { 'Test site' }
         allow(described_class).to receive(:matched_pages) { [foo_page, bar_page] }
       end
       it do
@@ -127,8 +99,8 @@ RSpec.describe Howitzer::Web::Page do
     context 'when page is not opened' do
       before do
         allow(described_class).to receive(:current_page) { 'FooPage' }
-        allow(described_class).to receive(:current_url) { 'http://test.com' }
-        allow(described_class).to receive(:title) { 'Test site' }
+        allow(session).to receive(:current_url) { 'http://test.com' }
+        allow(session).to receive(:title) { 'Test site' }
         allow(settings).to receive(:timeout_small) { 0.1 }
         allow(described_class).to receive(:opened?) { false }
       end

--- a/spec/unit/lib/web/page_spec.rb
+++ b/spec/unit/lib/web/page_spec.rb
@@ -4,6 +4,8 @@ require 'howitzer/web/blank_page'
 require 'howitzer/capybara_settings'
 
 RSpec.describe Howitzer::Web::Page do
+  let(:session) { double(:session) }
+  before { allow(Capybara).to receive(:current_session) { session } }
   describe '.open' do
     let(:retryable) { double }
     let(:check_correct_page_loaded) { double }
@@ -16,7 +18,7 @@ RSpec.describe Howitzer::Web::Page do
         expect(described_class).to receive(:expanded_url).with(id: 1) { url_value }.once.ordered
         expect(log).to receive(:info).with("Open #{described_class} page by '#{url_value}' url").once.ordered
         expect(described_class).to receive(:retryable).ordered.once.and_call_original
-        expect(described_class).to receive(:visit).with(url_value).once.ordered
+        expect(session).to receive(:visit).with(url_value).once.ordered
         expect(described_class).to receive(:given).once.ordered
         subject
       end
@@ -28,7 +30,7 @@ RSpec.describe Howitzer::Web::Page do
         expect(described_class).to receive(:expanded_url).with({}) { url_value }.once.ordered
         expect(log).to receive(:info).with("Open #{described_class} page by '#{url_value}' url").once.ordered
         expect(described_class).to receive(:retryable).ordered.once.and_call_original
-        expect(described_class).to receive(:visit).with(url_value).once.ordered
+        expect(session).to receive(:visit).with(url_value).once.ordered
         expect(described_class).to receive(:given).once.ordered
         subject
       end
@@ -49,11 +51,10 @@ RSpec.describe Howitzer::Web::Page do
     subject { described_class.instance.title }
     before do
       allow_any_instance_of(described_class).to receive(:check_validations_are_defined!) { true }
-      allow(described_class.instance).to receive(:current_url) { 'google.com' }
+      allow(session).to receive(:current_url) { 'google.com' }
     end
     it do
-      expect(described_class.instance).to receive(:page) { page }
-      expect(page).to receive(:title)
+      expect(session).to receive(:title)
       subject
     end
   end
@@ -62,8 +63,7 @@ RSpec.describe Howitzer::Web::Page do
     let(:page) { double }
     subject { described_class.current_url }
     it do
-      expect(described_class).to receive(:page) { page }
-      expect(page).to receive(:current_url) { 'google.com' }
+      expect(session).to receive(:current_url) { 'google.com' }
       is_expected.to eq('google.com')
     end
   end
@@ -72,8 +72,7 @@ RSpec.describe Howitzer::Web::Page do
     let(:page) { double }
     subject { described_class.current_url }
     it do
-      expect(described_class).to receive(:page) { page }
-      expect(page).to receive(:current_url) { 'google.com' }
+      expect(session).to receive(:current_url) { 'google.com' }
       is_expected.to eq('google.com')
     end
   end
@@ -83,8 +82,7 @@ RSpec.describe Howitzer::Web::Page do
     let(:find) { double }
     subject { described_class.text }
     it do
-      expect(described_class).to receive(:page) { page }
-      expect(page).to receive(:find).with('body') { find }
+      expect(session).to receive(:find).with('body') { find }
       expect(find).to receive(:text) { 'some body text' }
       is_expected.to eq('some body text')
     end
@@ -223,16 +221,17 @@ RSpec.describe Howitzer::Web::Page do
       expect_any_instance_of(described_class).to receive(:check_validations_are_defined!).once { true }
     end
     context 'when maximized_window is true' do
+      let(:driver) { double }
       before { allow(settings).to receive(:maximized_window) { true } }
       it do
-        expect_any_instance_of(described_class).to receive_message_chain('page.driver.browser.manage.window.maximize')
+        expect_any_instance_of(described_class).to receive_message_chain('driver.browser.manage.window.maximize')
         subject
       end
     end
     context 'when maximized_window is false' do
       before { allow(settings).to receive(:maximized_window) { false } }
       it do
-        expect_any_instance_of(described_class).not_to receive('page')
+        expect_any_instance_of(described_class).not_to receive(:driver)
         subject
       end
     end
@@ -254,7 +253,8 @@ RSpec.describe Howitzer::Web::Page do
     before do
       allow(settings).to receive(:driver) { driver_name }
       allow(settings).to receive(:timeout_tiny) { 0 }
-      allow(described_class.instance).to receive(:current_url) { 'google.com' }
+      allow(session).to receive(:current_url) { 'google.com' }
+      allow_any_instance_of(described_class).to receive(:check_validations_are_defined!) { true }
     end
     context 'when flag true and correct driver specified' do
       let(:flag_value) { true }
@@ -265,8 +265,7 @@ RSpec.describe Howitzer::Web::Page do
       let(:switch_to) { double }
       let(:driver_name) { 'selenium' }
       it do
-        expect(described_class.instance).to receive(:page) { page }
-        expect(page).to receive(:driver).ordered { driver }
+        expect(session).to receive(:driver).ordered { driver }
         expect(driver).to receive(:browser).ordered { browser }
         expect(browser).to receive(:switch_to).ordered { switch_to }
         expect(switch_to).to receive(:alert).ordered { alert }
@@ -283,8 +282,7 @@ RSpec.describe Howitzer::Web::Page do
       let(:switch_to) { double }
       let(:driver_name) { 'selenium' }
       it do
-        expect(described_class.instance).to receive(:page) { page }
-        expect(page).to receive(:driver).ordered { driver }
+        expect(session).to receive(:driver).ordered { driver }
         expect(driver).to receive(:browser).ordered { browser }
         expect(browser).to receive(:switch_to).ordered { switch_to }
         expect(switch_to).to receive(:alert).ordered { alert }
@@ -297,8 +295,7 @@ RSpec.describe Howitzer::Web::Page do
       let(:page) { double }
       let(:driver_name) { 'ff' }
       it do
-        expect(described_class.instance).to receive(:page) { page }
-        expect(page).to receive(:evaluate_script).with('window.confirm = function() { return true; }')
+        expect(session).to receive(:evaluate_script).with('window.confirm = function() { return true; }')
         subject
       end
     end
@@ -307,8 +304,7 @@ RSpec.describe Howitzer::Web::Page do
       let(:flag_value) { false }
       let(:page) { double }
       it do
-        expect(described_class.instance).to receive(:page) { page }
-        expect(page).to receive(:evaluate_script).with('window.confirm = function() { return false; }')
+        expect(session).to receive(:evaluate_script).with('window.confirm = function() { return false; }')
         subject
       end
     end
@@ -319,11 +315,11 @@ RSpec.describe Howitzer::Web::Page do
     subject { described_class.instance.reload }
     let(:visit) { double }
     before do
-      allow(described_class.instance).to receive(:current_url) { 'google.com' }
+      allow(session).to receive(:current_url) { 'google.com' }
     end
     it do
       expect(log).to receive(:info) { "Reload 'google.com'" }
-      expect(described_class.instance).to receive(:visit).with('google.com')
+      expect(session).to receive(:visit).with('google.com')
       subject
     end
   end

--- a/spec/unit/lib/web/page_validator_spec.rb
+++ b/spec/unit/lib/web/page_validator_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe Howitzer::Web::PageValidator do
     context 'when all validations are defined' do
       before do
         web_page_class.class_eval do
+          include Singleton
           element :login, '#id'
           validate :url, /foo/
           validate :title, /Foo page/
@@ -169,16 +170,16 @@ RSpec.describe Howitzer::Web::PageValidator do
       end
       context 'when all matches' do
         before do
-          allow(web_page_class).to receive(:current_url) { 'http://test.com/foo' }
-          allow(web_page_class).to receive(:title) { 'Foo page' }
+          allow(web_page_class.instance).to receive(:current_url) { 'http://test.com/foo' }
+          allow(web_page_class.instance).to receive(:title) { 'Foo page' }
           allow(web_page_class).to receive(:has_login_element?).with(no_args) { true }
         end
         it { is_expected.to be_truthy }
       end
       context 'when first validation fails' do
         before do
-          expect(web_page_class).to receive(:current_url).once { 'http://test.com/bar' }
-          expect(web_page_class).to receive(:title).never
+          expect(web_page_class.instance).to receive(:current_url).once { 'http://test.com/bar' }
+          expect(web_page_class.instance).to receive(:title).never
           allow(web_page_class).to receive(:has_login_element?).with(no_args).never
         end
         it { is_expected.to be_falsey }


### PR DESCRIPTION
The main reason to do so is preventing of design patterns dropping by engineers. There is always temptation use native capybara commands breaking Page object pattern and Howitzer concepts