### PR TITLE
replaced wait_for_opened to displayed? for readibility

### DIFF
--- a/lib/howitzer/utils/string_extensions.rb
+++ b/lib/howitzer/utils/string_extensions.rb
@@ -28,8 +28,8 @@ module Howitzer
       # Waits until page is opened or raise error
       #
 
-      def wait_for_opened
-        as_page_class.wait_for_opened
+      def displayed?
+        as_page_class.displayed?
       end
 
       ##

--- a/lib/howitzer/web/page.rb
+++ b/lib/howitzer/web/page.rb
@@ -61,7 +61,7 @@ module Howitzer
       #
 
       def self.given
-        wait_for_opened
+        displayed?
         instance
       end
 
@@ -92,9 +92,12 @@ module Howitzer
       # * +time_out+ - Seconds that will be waiting for web page to be loaded
       #
 
-      def self.wait_for_opened(timeout = settings.timeout_small)
+      def self.displayed?(timeout = settings.timeout_small)
         end_time = ::Time.now + timeout
-        opened? ? return : sleep(0.5) until ::Time.now > end_time
+        until ::Time.now > end_time
+          return true if opened?
+          sleep(0.5)
+        end
         log.error IncorrectPageError, incorrect_page_msg
       end
 

--- a/spec/unit/lib/utils/string_spec.rb
+++ b/spec/unit/lib/utils/string_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Howitzer::Utils::StringExtensions do
     end
     it { is_expected.to be_nil }
   end
-  describe '#wait_for_opened' do
-    subject { page_name.wait_for_opened }
+  describe '#displayed?' do
+    subject { page_name.displayed? }
     before do
       allow(page_name).to receive(:as_page_class) { page_object }
-      expect(page_object).to receive(:wait_for_opened).once
+      expect(page_object).to receive(:displayed?).once
     end
     it { is_expected.to be_nil }
   end

--- a/spec/unit/lib/web/page_spec.rb
+++ b/spec/unit/lib/web/page_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Howitzer::Web::Page do
   describe '.given' do
     subject { described_class.given }
     before do
-      expect(described_class).to receive(:wait_for_opened).with(no_args).once
+      expect(described_class).to receive(:displayed?).with(no_args).once
       expect(described_class).to receive(:instance) { true }
     end
     it { is_expected.to be_truthy }
@@ -90,11 +90,11 @@ RSpec.describe Howitzer::Web::Page do
     end
   end
 
-  describe '.wait_for_opened' do
-    subject { described_class.wait_for_opened }
+  describe '.displayed?' do
+    subject { described_class.displayed? }
     context 'when page is opened' do
       before { allow(described_class).to receive(:opened?) { true } }
-      it { is_expected.to be_nil }
+      it { is_expected.to eq(true) }
     end
     context 'when page is not opened' do
       before do


### PR DESCRIPTION
Now we can have in tests:

expect(HomePage).to be_displayed

It will wait till page is opened or raise error