### PR TITLE
Idle for single email

### DIFF
--- a/generators/config/templates/default.yml
+++ b/generators/config/templates/default.yml
@@ -81,7 +81,9 @@
 # MAIL SETTINGS                                           #
 ###########################################################
  mail_adapter: mailgun
+ mail_wait_time: 60
+
+# -Mailgun- (http://www.mailgun.com/)
  mailgun_key: mailgun_account_private_key
  mailgun_domain: mailgun_domain_with_stored_method
- mailgun_idle_timeout: 60
  mailgun_sleep_time: 3

--- a/lib/howitzer.rb
+++ b/lib/howitzer.rb
@@ -18,8 +18,11 @@ module Howitzer
     ::SexySettings::Base.instance.all.each do |key, value|
       define_method(key) { value }
     end
-
     attr_accessor :current_rake_task
+  end
+
+  if defined?(mailgun_idle_timeout)
+    puts "WARNING! 'mailgun_idle_timeout' setting is deprecated. Please replace with 'mail_wait_time' setting."
   end
 
   # @return an application uri

--- a/lib/howitzer.rb
+++ b/lib/howitzer.rb
@@ -18,11 +18,13 @@ module Howitzer
     ::SexySettings::Base.instance.all.each do |key, value|
       define_method(key) { value }
     end
-    attr_accessor :current_rake_task
-  end
 
-  if defined?(mailgun_idle_timeout)
-    puts "WARNING! 'mailgun_idle_timeout' setting is deprecated. Please replace with 'mail_wait_time' setting."
+    def mailgun_idle_timeout
+      puts "WARNING! 'mailgun_idle_timeout' setting is deprecated. Please replace with 'mail_wait_time' setting."
+      ::SexySettings::Base.instance.all['mailgun_idle_timeout']
+    end
+
+    attr_accessor :current_rake_task
   end
 
   # @return an application uri

--- a/lib/howitzer/mail_adapters/abstract.rb
+++ b/lib/howitzer/mail_adapters/abstract.rb
@@ -19,8 +19,9 @@ module Howitzer
       # Finds an email in mailbox
       # @param _recipient [String] an email
       # @param _subject [String]
+      # @param _wait [Integer] how much time is required to wait an email
 
-      def self.find(_recipient, _subject)
+      def self.find(_recipient, _subject, _wait:)
         raise NotImplementedError
       end
 

--- a/lib/howitzer/mail_adapters/mailgun.rb
+++ b/lib/howitzer/mail_adapters/mailgun.rb
@@ -15,7 +15,7 @@ module Howitzer
 
       def self.find(recipient, subject, wait:)
         message = {}
-        retryable(find_retry_params.merge(timeout: wait)) { message = retrieve_message(recipient, subject) }
+        retryable(find_retry_params(wait)) { message = retrieve_message(recipient, subject) }
         return new(message) if message.present?
         raise Howitzer::EmailNotFoundError,
               "Message with subject '#{subject}' for recipient '#{recipient}' was not found."
@@ -92,8 +92,9 @@ module Howitzer
       end
       private_class_method :event_by
 
-      def self.find_retry_params
+      def self.find_retry_params(wait)
         {
+          timeout: wait || Howitzer.try(:mailgun_idle_timeout),
           sleep: Howitzer.mailgun_sleep_time,
           silent: true,
           logger: Howitzer::Log,

--- a/lib/howitzer/mail_adapters/mailgun.rb
+++ b/lib/howitzer/mail_adapters/mailgun.rb
@@ -10,11 +10,12 @@ module Howitzer
       # @note emails are stored for 3 days only!
       # @param recipient [String] an email
       # @param subject [String]
-      # @raise [EmailNotFoundError] if message blank
+      # @param wait [Integer] how much time is required to wait an email
+      # @raise [EmailNotFoundError] if blank message
 
-      def self.find(recipient, subject)
+      def self.find(recipient, subject, wait:)
         message = {}
-        retryable(find_retry_params) { message = retrieve_message(recipient, subject) }
+        retryable(find_retry_params.merge(timeout: wait)) { message = retrieve_message(recipient, subject) }
         return new(message) if message.present?
         raise Howitzer::EmailNotFoundError,
               "Message with subject '#{subject}' for recipient '#{recipient}' was not found."
@@ -93,7 +94,6 @@ module Howitzer
 
       def self.find_retry_params
         {
-          timeout: Howitzer.mailgun_idle_timeout,
           sleep: Howitzer.mailgun_sleep_time,
           silent: true,
           logger: Howitzer::Log,

--- a/lib/howitzer/web/page.rb
+++ b/lib/howitzer/web/page.rb
@@ -97,8 +97,8 @@ module Howitzer
       # @raise [NoPathForPageError] if an url is not specified for the page
 
       def self.expanded_url(params = {}, url_processor = nil)
-        unless path_template.nil?
-          return "#{app_host}#{Addressable::Template.new(path_template).expand(params, url_processor)}"
+        if defined?(path_value)
+          return "#{site_value}#{Addressable::Template.new(path_value).expand(params, url_processor)}"
         end
         raise Howitzer::NoPathForPageError, "Please specify path for '#{self}' page. Example: path '/home'"
       end
@@ -117,7 +117,8 @@ module Howitzer
         # @!visibility public
 
         def path(value)
-          @path_template = value.to_s
+          define_singleton_method(:path_value) { value.to_s }
+          private_class_method :path_value
         end
 
         # DSL to specify a site for the page opening
@@ -134,13 +135,11 @@ module Howitzer
         # @!visibility public
 
         def site(value)
-          define_singleton_method(:app_host) { value }
-          private_class_method :app_host
+          define_singleton_method(:site_value) { value }
+          private_class_method :site_value
         end
 
         private
-
-        attr_reader :path_template
 
         def incorrect_page_msg
           "Current page: #{current_page}, expected: #{self}.\n" \

--- a/spec/config/custom.yml
+++ b/spec/config/custom.yml
@@ -1,7 +1,6 @@
 log_dir: "spec/log"
 driver: selenium
 mailgun_domain: mailgun@test.domain
-mailgun_idle_timeout: 0.5
 mailgun_sleep_time: 0.05
 page_load_idle_timeout: 0.1
 capybara_wait_time: 5

--- a/spec/config/custom.yml
+++ b/spec/config/custom.yml
@@ -7,3 +7,4 @@ capybara_wait_time: 5
 cloud_http_idle_timeout: 10
 hide_datetime_from_log: true
 maximized_window: false
+mailgun_idle_timeout: 0.5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,11 +69,5 @@ Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }
 RSpec.configure do |config|
   config.include Howitzer::GeneratorHelper
   config.disable_monkey_patching = true
-  config.around(:each) do |ex|
-    $stdout = StringIO.new
-    $stderr = StringIO.new
-    ex.run
-    $stdout = STDOUT
-    $stderr = STDERR
-  end
+  config.around(:each, &:run)
 end

--- a/spec/unit/lib/howitzer_spec.rb
+++ b/spec/unit/lib/howitzer_spec.rb
@@ -28,4 +28,13 @@ RSpec.describe 'Howitzer' do
       it { expect(Howitzer.app_uri.site).to eq('http://redmine.strongqa.com') }
     end
   end
+  describe '.mailgun_idle_timeout' do
+    subject { Howitzer.mailgun_idle_timeout }
+    before do
+      expect_any_instance_of(Object).to receive(:puts).with(
+        "WARNING! 'mailgun_idle_timeout' setting is deprecated. Please replace with 'mail_wait_time' setting."
+      )
+    end
+    it { is_expected.to eq(0.5) }
+  end
 end

--- a/spec/unit/lib/mail_adapters/abstract_spec.rb
+++ b/spec/unit/lib/mail_adapters/abstract_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Howitzer::MailAdapters::Abstract do
   let(:email_object) { Howitzer::Email.adapter.new(message) }
 
   describe '.find' do
-    subject { described_class.find(recipient, message_subject) }
+    subject { described_class.find(recipient, message_subject, wait: 10) }
     it { expect { subject }.to raise_error(NotImplementedError) }
   end
 

--- a/spec/unit/lib/mail_adapters/abstract_spec.rb
+++ b/spec/unit/lib/mail_adapters/abstract_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Howitzer::MailAdapters::Abstract do
   let(:email_object) { Howitzer::Email.adapter.new(message) }
 
   describe '.find' do
-    subject { described_class.find(recipient, message_subject, wait: 10) }
+    subject { described_class.find(recipient, message_subject, _wait: 10) }
     it { expect { subject }.to raise_error(NotImplementedError) }
   end
 

--- a/spec/unit/lib/mail_adapters/mailgun_spec.rb
+++ b/spec/unit/lib/mail_adapters/mailgun_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Mailgun Email Adapter' do
   describe '.find' do
     let(:mailgun_message) { double(to_h: message) }
     let(:events) { double(to_h: { 'items' => [event] }) }
-    subject { Howitzer::MailAdapters::Mailgun.find(recipient, message_subject) }
+    subject { Howitzer::MailAdapters::Mailgun.find(recipient, message_subject, wait: 0.01) }
 
     context 'when message is found' do
       let(:event) do

--- a/spec/unit/lib/web/page_spec.rb
+++ b/spec/unit/lib/web/page_spec.rb
@@ -176,11 +176,11 @@ RSpec.describe Howitzer::Web::Page do
     let!(:child_class3) do
       Class.new(described_class)
     end
-    it { expect(described_class.send(:app_host)).to eq('http://login:pass@my.website.com') }
-    it { expect(base_class.send(:app_host)).to eq('https://base.com') }
-    it { expect(child_class1.send(:app_host)).to eq('https://child.com') }
-    it { expect(child_class2.send(:app_host)).to eq('https://base.com') }
-    it { expect(child_class3.send(:app_host)).to eq('http://login:pass@my.website.com') }
+    it { expect(described_class.send(:site_value)).to eq('http://login:pass@my.website.com') }
+    it { expect(base_class.send(:site_value)).to eq('https://base.com') }
+    it { expect(child_class1.send(:site_value)).to eq('https://child.com') }
+    it { expect(child_class2.send(:site_value)).to eq('https://base.com') }
+    it { expect(child_class3.send(:site_value)).to eq('http://login:pass@my.website.com') }
     it 'should be protected' do
       expect { described_class.site('http://example.com') }.to raise_error(NoMethodError)
     end
@@ -270,11 +270,16 @@ RSpec.describe Howitzer::Web::Page do
     before { subject }
     context 'when value is number' do
       let(:value) { 1 }
-      it { expect(described_class.instance_variable_get(:@path_template)).to eq('1') }
+      it do
+        expect(described_class.send(:path_value)).to eql '1'
+        expect(described_class.private_methods(true)).to include(:path_value)
+      end
     end
     context 'when value is string' do
       let(:value) { '/users' }
-      it { expect(described_class.instance_variable_get(:@path_template)).to eq('/users') }
+      it do
+        expect(described_class.send(:path_value)).to eql '/users'
+      end
     end
   end
 


### PR DESCRIPTION
new dsl method is introduced for Email class

```ruby

class MyEmail < Howitzer::Email
  wait_time 10.minutes
end
```

New setting was introduced `mail_wait_time` as replacement of `maigun_idle_timeout`