### PR TITLE
Headless chrome feature added

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ You can also find the Rdoc documentation on [Rubygems](https://rubygems.org/gems
 * [Ruby](https://www.ruby-lang.org/en/downloads/) 2.2.2+
 * [DevKit](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#installation-instructions) (For **Windows** only)
 * [PhantomJS](http://phantomjs.org/download.html) (For **phantomjs** and **poltergeist** drivers only)
-* [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/) (For **chrome** selenium browser)
+* [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/) (For **chrome** selenium browser, 2.29+ for headless mode)
 * [GeckoDriver](https://github.com/mozilla/geckodriver/releases) (For **firefox** selenium browser)
 * [SafariDriver](https://webkit.org/blog/6900/webdriver-support-in-safari-10/) (For **safari** selenium browser)
 * [QT](https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit) (For **webkit** driver only)
-
+* [Chrome](https://www.google.com/chrome/browser/desktop/index.html) v.59+ (For **headless chrome** support)
 ## Setup
 To install, type
 

--- a/generators/config/templates/capybara.rb
+++ b/generators/config/templates/capybara.rb
@@ -39,6 +39,9 @@ end
 
 Capybara.register_driver :selenium do |app|
   params = { browser: Howitzer.selenium_browser.to_s.to_sym }
+  if CapybaraHelpers.chrome_browser? && Howitzer.chrome_headless_mode
+    params[:switches] = %w[--headless --disable-gpu -start-maximized]
+  end
   if CapybaraHelpers.ff_browser?
     ff_profile = Selenium::WebDriver::Firefox::Profile.new.tap do |profile|
       profile['network.http.phishy-userpass-length'] = 255

--- a/generators/config/templates/capybara.rb
+++ b/generators/config/templates/capybara.rb
@@ -58,7 +58,7 @@ end
 Capybara.register_driver :headless_chrome do |app|
   startup_flags = ['--headless']
   startup_flags << '-start-maximized' if Howitzer.maximized_window
-  startup_flags.concat(Howitzer.flags) if Howitzer.flags
+  startup_flags.concat(Howitzer.headless_chrome_flags.split(/\s*,\s*/)) if Howitzer.headless_chrome_flags
   params = { browser: :chrome, switches: startup_flags }
   Capybara::Selenium::Driver.new app, params
 end

--- a/generators/config/templates/default.yml
+++ b/generators/config/templates/default.yml
@@ -26,7 +26,10 @@
 
  # -Selenium-
  # specify one of next browsers: iexplore (ie), firefox (ff), chrome, safari
+ # NOTE: To run chrome in headless mode maximized_window option should be false,
+ # chrome version >= 59, chromedriver version >= 2.29
  selenium_browser: ff
+ chrome_headless_mode: false
 
  # -Selenium Grid-
  selenium_hub_url: "http://example.com:4444/wd/hub"

--- a/generators/config/templates/default.yml
+++ b/generators/config/templates/default.yml
@@ -30,7 +30,7 @@
 
  # -Headless Chrome-
  # List of available flags (http://peter.sh/experiments/chromium-command-line-switches/)
- flags: [--window-size=1920x1080, --disable-gpu]
+ headless_chrome_flags: "--window-size=1920x1080, --disable-gpu"
 
  # -Selenium Grid-
  selenium_hub_url: "http://example.com:4444/wd/hub"

--- a/generators/config/templates/default.yml
+++ b/generators/config/templates/default.yml
@@ -21,15 +21,16 @@
  maximized_window: true # Specify maximized browser window size
 
  # Specify one of the following drivers: selenium, selenium_grid, webkit, poltergeist, phantomjs, sauce,
- # testingbot, browserstack
+ # testingbot, browserstack, headless_chrome
  driver: phantomjs
 
  # -Selenium-
  # specify one of next browsers: iexplore (ie), firefox (ff), chrome, safari
- # NOTE: To run chrome in headless mode maximized_window option should be false,
- # chrome version >= 59, chromedriver version >= 2.29
  selenium_browser: ff
- chrome_headless_mode: false
+
+ # -Headless Chrome-
+ # List of available flags (http://peter.sh/experiments/chromium-command-line-switches/)
+ flags: [--window-size=1920x1080, --disable-gpu]
 
  # -Selenium Grid-
  selenium_hub_url: "http://example.com:4444/wd/hub"

--- a/generators/config/templates/default.yml
+++ b/generators/config/templates/default.yml
@@ -18,7 +18,7 @@
 # TEST ENVIRONMENTS SETTINGS                              #
 ###########################################################
  page_load_idle_timeout: 20
-   maximized_window: true # Specify maximized browser window size
+ maximized_window: true # Specify maximized browser window size
 
  # Specify one of the following drivers: selenium, selenium_grid, webkit, poltergeist, phantomjs, sauce,
  # testingbot, browserstack

--- a/generators/config/templates/default.yml
+++ b/generators/config/templates/default.yml
@@ -18,7 +18,7 @@
 # TEST ENVIRONMENTS SETTINGS                              #
 ###########################################################
  page_load_idle_timeout: 20
- maximized_window: true # Specify maximized browser window size
+   maximized_window: true # Specify maximized browser window size
 
  # Specify one of the following drivers: selenium, selenium_grid, webkit, poltergeist, phantomjs, sauce,
  # testingbot, browserstack

--- a/generators/emails/templates/example_email.rb
+++ b/generators/emails/templates/example_email.rb
@@ -3,6 +3,6 @@ class TestEmail < Howitzer::Email
   subject 'Test email'
 
   def addressed_to?(new_user)
-    plain_text_body.match?(/Hi #{new_user}/)
+    plain_text_body =~ /Hi #{new_user}/ ? true : false
   end
 end

--- a/generators/emails/templates/example_email.rb
+++ b/generators/emails/templates/example_email.rb
@@ -3,6 +3,6 @@ class TestEmail < Howitzer::Email
   subject 'Test email'
 
   def addressed_to?(new_user)
-    /Hi #{new_user}/ === plain_text_body
+    plain_text_body === /Hi #{new_user}/
   end
 end

--- a/generators/emails/templates/example_email.rb
+++ b/generators/emails/templates/example_email.rb
@@ -3,6 +3,6 @@ class TestEmail < Howitzer::Email
   subject 'Test email'
 
   def addressed_to?(new_user)
-    plain_text_body === /Hi #{new_user}/
+    plain_text_body =~ /Hi #{new_user}/
   end
 end

--- a/generators/emails/templates/example_email.rb
+++ b/generators/emails/templates/example_email.rb
@@ -3,6 +3,6 @@ class TestEmail < Howitzer::Email
   subject 'Test email'
 
   def addressed_to?(new_user)
-    plain_text_body =~ /Hi #{new_user}/
+    plain_text_body.match?(/Hi #{new_user}/)
   end
 end

--- a/lib/howitzer/web/page.rb
+++ b/lib/howitzer/web/page.rb
@@ -153,7 +153,7 @@ module Howitzer
 
       def initialize
         check_validations_are_defined!
-        current_window.maximize if Howitzer.maximized_window
+        current_window.maximize if Howitzer.maximized_window && Howitzer.driver != 'headless_chrome'
       end
 
       # Reloads current page in a browser

--- a/spec/unit/lib/web/page_spec.rb
+++ b/spec/unit/lib/web/page_spec.rb
@@ -296,6 +296,16 @@ RSpec.describe Howitzer::Web::Page do
         subject
       end
     end
+    context 'when maximized_window is true and driver is headless_chrome' do
+      before do
+        allow(Howitzer).to receive(:maximized_window) { true }
+        allow(Howitzer).to receive(:driver) { 'headless_chrome' }
+      end
+      it do
+        expect_any_instance_of(described_class).not_to receive('current_window.maximize')
+        subject
+      end
+    end
     context 'when maximized_window is false' do
       before { allow(Howitzer).to receive(:maximized_window) { false } }
       it do


### PR DESCRIPTION
Headless Chrome feature added.

Prerequisites to use:
- Chrome version >= 59
- chromedriver >= 2.29
- Howitzer option "maximized_window" should be set to false, due to window resizing extension fail in headless mode. (currently headless chrome started with maximized window by default with argument 
"-start-maximized" )