### PR TITLE
Allow gemfile.lock modify

### DIFF
--- a/generators/root/templates/Dockerfile
+++ b/generators/root/templates/Dockerfile
@@ -27,7 +27,7 @@ USER howitzer
 WORKDIR /home/howitzer
 
 COPY --chown=howitzer Gemfile Gemfile.lock /home/howitzer/
-RUN bundle config --global frozen 1 && bundle install --jobs=3 --retry=3
+RUN bundle config --global && bundle install --jobs=3 --retry=3
 
 COPY --chown=howitzer . ./
 


### PR DESCRIPTION
On step installing the dependencies removed key parameter "frozen 1", its mostly used for production environments.
In our case it was considered to use Docekrfile and  Docker compose files for local development as well, where modifying Gemfile.lock file is preferably.